### PR TITLE
Minor grammar tweaks in docs

### DIFF
--- a/_posts/2018-04-10-Menuapp.md
+++ b/_posts/2018-04-10-Menuapp.md
@@ -5,11 +5,11 @@ permalink: Menuapp
 ---
 This is the `menu app` (RsyncOSXsched.app) for executing scheduled tasks in RsyncOSX. Scheduled tasks are added in RsyncOSX. Quit RsyncOSX and let the menu app take care of executing the scheduled tasks. RsyncOSX does **not** execute scheduled tasks. Scheduled tasks are only added and deleted in RsyncOSX.
 
-The `menu app` can be started from RsyncOSX. This require paths for both apps to be entered into userconfiguration.  The paths are used for activating the apps from either within RsyncOSX or RsyncOSXsched.
+The `menu app` can be started from RsyncOSX. This requires the paths for both apps to be entered into userconfiguration.  The paths are used for activating the apps from either within RsyncOSX or RsyncOSXsched.
 
 ![](/images/RsyncOSX/master/menuapp/userconfig.png).
 
-The `menu app` submit a notification when a scheduled tasks is completed. A scheduled task is either of type `once`, `daily` or `weekly`. If there are tasks waiting for executing the status light is green.
+The `menu app` submits a notification when a scheduled tasks are completed. A scheduled task is either of type `once`, `daily` or `weekly`. If there are tasks waiting to execute the status light will be green.
 
 ![](/images/RsyncOSX/master/menuapp/menuapp1.png)
 


### PR DESCRIPTION
Noticed a few minor gramma typos and figured I'd fire off a PR.

Thanks for the work on these rclone / rsync GUIs. The ability to see from the menu bar that scheduled tasks are running is a huge win.